### PR TITLE
Fix: load MCP SDK modules with runtime dynamic import

### DIFF
--- a/nodes/McpClient/McpClient.node.ts
+++ b/nodes/McpClient/McpClient.node.ts
@@ -7,6 +7,11 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 
+const dynamicImport: <T>(specifier: string) => Promise<T> = new Function(
+        'specifier',
+        'return import(specifier);',
+) as <T>(specifier: string) => Promise<T>;
+
 interface McpClientModule {
         Client: new (options?: IDataObject) => {
                 connect: (transport: McpTransport) => Promise<void>;
@@ -192,7 +197,7 @@ export class McpClient implements INodeType {
 
                 let sdk: McpClientModule;
                 try {
-                        sdk = (await import('@modelcontextprotocol/sdk/client/index.js')) as unknown as McpClientModule;
+                        sdk = await dynamicImport<McpClientModule>('@modelcontextprotocol/sdk/client/index.js');
                 } catch (error) {
                         throw new NodeOperationError(
                                 this.getNode(),

--- a/nodes/McpServerTrigger/McpServerTrigger.node.ts
+++ b/nodes/McpServerTrigger/McpServerTrigger.node.ts
@@ -8,6 +8,11 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 
+const dynamicImport: <T>(specifier: string) => Promise<T> = new Function(
+        'specifier',
+        'return import(specifier);',
+) as <T>(specifier: string) => Promise<T>;
+
 interface ToolConfig {
         name: string;
         description?: string;
@@ -469,7 +474,7 @@ export class McpServerTrigger implements INodeType {
 
                 let sdk: McpServerModule;
                 try {
-                        sdk = (await import('@modelcontextprotocol/sdk/server/index.js')) as unknown as McpServerModule;
+                        sdk = await dynamicImport<McpServerModule>('@modelcontextprotocol/sdk/server/index.js');
                 } catch (error) {
                         throw new NodeOperationError(
                                 this.getNode(),


### PR DESCRIPTION
## Summary
- add a runtime dynamic import helper so the MCP client SDK loads under CommonJS
- reuse the helper in the MCP server trigger to avoid ERR_REQUIRE_ESM at runtime

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e55e07925c832d822b48dcce7e7865